### PR TITLE
Add Atomic Swap Selling state machine and implementation

### DIFF
--- a/src/Swaps/AssemblyInfo.fs
+++ b/src/Swaps/AssemblyInfo.fs
@@ -1,0 +1,41 @@
+﻿namespace Swaps.AssemblyInfo
+
+open System.Reflection
+open System.Runtime.CompilerServices
+open System.Runtime.InteropServices
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[<assembly: AssemblyTitle("Swaps")>]
+[<assembly: AssemblyDescription("")>]
+[<assembly: AssemblyConfiguration("")>]
+[<assembly: AssemblyCompany("")>]
+[<assembly: AssemblyProduct("Swaps")>]
+[<assembly: AssemblyCopyright("Copyright ©  $year$")>]
+[<assembly: AssemblyTrademark("")>]
+[<assembly: AssemblyCulture("")>]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[<assembly: ComVisible(false)>]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[<assembly: Guid("56976F07-D182-4388-88F3-6FEB8C85C755")>]
+
+// Version information for an assembly consists of the following four values:
+// 
+//       Major Version
+//       Minor Version 
+//       Build Number
+//       Revision
+// 
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [<assembly: AssemblyVersion("1.0.*")>]
+[<assembly: AssemblyVersion("1.0.0.0")>]
+[<assembly: AssemblyFileVersion("1.0.0.0")>]
+
+do
+    ()

--- a/src/Swaps/Implementations.fs
+++ b/src/Swaps/Implementations.fs
@@ -1,0 +1,39 @@
+module Swaps.Imp
+
+open Swaps.Selling
+
+let shouldCreateContract order buyer =
+    let isMatchingOrder order (output: NBitcoin.TxOut) =
+        output.ScriptPubKey = order.BTCAddress.ScriptPubKey && uint64(output.Value.Satoshi) = order.BTCAmount
+
+    if buyer.BTCTx.Check() = NBitcoin.TransactionCheckResult.Success
+    then
+        let outputs = List.ofSeq buyer.BTCTx.Outputs
+        match List.tryFind (isMatchingOrder order) outputs with 
+            | Some _ -> true
+            | None -> false
+    else
+    false
+        
+
+let activateContract getZenClient generateContractCode getPassword order (buyer: Buyer) =
+    let result = Messaging.Services.Wallet.activateContract (getZenClient ()) true (generateContractCode order buyer) order.ZPActivationBlocks (getPassword ())
+    match result with
+    | Ok res ->
+        let _, contract = res
+        Ok contract
+    | Error err -> Error err
+
+
+let isSwapExpired getZenClient order =
+    let info = Messaging.Services.Blockchain.getBlockChainInfo (getZenClient ())
+    info.headers > order.ZPExpiry
+
+
+let isBTCConfirmed (getNinjaClient: unit -> QBitNinja.Client.QBitNinjaClient) order buyer = 
+    let client = getNinjaClient ()
+    let res = (client.GetTransaction (buyer.BTCTx.GetHash ())).Result
+    match res with
+    | null -> false 
+    | _ -> uint32(res.Block.Confirmations) >= order.BTCRequiredConfirmations
+

--- a/src/Swaps/Program.fs
+++ b/src/Swaps/Program.fs
@@ -1,0 +1,4 @@
+﻿[<EntryPoint>]
+let main argv = 
+    printfn "%A" argv
+    0 // return an integer exit code

--- a/src/Swaps/Selling.fs
+++ b/src/Swaps/Selling.fs
@@ -1,0 +1,72 @@
+module Swaps.Selling
+
+type Order =
+    {
+        ZPAmount: uint64
+        ZPExpiry: uint32
+        ZPActivationBlocks: uint32
+        BTCAmount: uint64
+        BTCRequiredConfirmations: uint32
+        BTCAddress: NBitcoin.BitcoinAddress
+    }
+
+type Buyer =
+    {
+        BTCTx: NBitcoin.Transaction
+        ZPLock: Consensus.Types.Lock
+    }
+    
+type ContractActivationResult = Result<Consensus.Types.ContractId, string>
+
+// State Data
+
+type OrderCreatedData = Order
+type ReadyForContractData = Order * Buyer
+type ContractActivatedData = Order * Buyer * Consensus.Types.ContractId
+type SuccessData = Order * Buyer * Consensus.Types.ContractId
+type FailureData = string
+
+// States
+
+type Swap =
+| OrderCreatedState of OrderCreatedData
+| ReadyForContractState of ReadyForContractData
+| ContractActivatedState of ContractActivatedData
+| SuccessState of SuccessData
+| FailureState of FailureData
+
+// Transitions
+
+let transitionFromFailure (data: FailureData) = FailureState data
+
+
+let transitionFromSuccess (data: SuccessData) = SuccessState data
+
+
+let transitionFromOrderCreated shouldCreateContract (data: OrderCreatedData) (buyer: Buyer) =
+    if shouldCreateContract data buyer
+    then
+        (data, buyer) |> ReadyForContractState
+    else 
+        FailureState "buyer doesn't match order"
+
+
+let transitionFromReadyForContract (activateContract: Order -> Buyer -> ContractActivationResult) (data: ReadyForContractData) =
+    let order, buyer = data
+    let result = activateContract order buyer
+    match result with 
+    | Ok contract -> (order, buyer, contract) |> ContractActivatedState
+    | Error err -> err |> FailureState
+
+
+let transitionFromContractActivated isSwapExpired isBTCConfirmed (data: ContractActivatedData) =
+    let order, buyer, _ = ContractActivatedData data
+    if isBTCConfirmed order buyer
+    then
+        data |> SuccessState
+    else
+        if !isSwapExpired order
+        then
+            data |> ContractActivatedState
+        else 
+            FailureState "swap expired with no payment"

--- a/src/Swaps/Swaps.fsproj
+++ b/src/Swaps/Swaps.fsproj
@@ -1,0 +1,109 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="..\packages\FSharp.Compiler.Tools.10.0.1\build\FSharp.Compiler.Tools.props" Condition="Exists('..\packages\FSharp.Compiler.Tools.10.0.1\build\FSharp.Compiler.Tools.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{56976F07-D182-4388-88F3-6FEB8C85C755}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>Swaps</RootNamespace>
+    <AssemblyName>Swaps</AssemblyName>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <DocumentationFile>bin\$(Configuration)\$(AssemblyName).xml</DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <Tailcalls>false</Tailcalls>
+    <OutputPath>bin\$(Configuration)\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <OtherFlags>--warnon:1182</OtherFlags>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <Tailcalls>true</Tailcalls>
+    <OutputPath>bin\$(Configuration)\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <OtherFlags>--warnon:1182</OtherFlags>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="FsNetMQ, Version=0.2.8.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\packages\FsNetMQ\lib\net452\FsNetMQ.dll</HintPath>
+    </Reference>
+    <Reference Include="mscorlib" />
+    <Reference Include="NBitcoin, Version=4.1.1.1, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\NBitcoin.4.1.1.1\lib\net461\NBitcoin.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
+      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="QBitNinja.Client, Version=1.0.3.47, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\QBitNinja.Client.1.0.3.47\lib\net461\QBitNinja.Client.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.IO, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\packages\System.IO.4.3.0\lib\net462\System.IO.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Net.Http, Version=4.1.1.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\packages\System.Net.Http.4.3.2\lib\net46\System.Net.Http.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Numerics" />
+    <Reference Include="FSharp.Core">
+      <HintPath>..\packages\FSharp.Core.4.3.4\lib\net45\FSharp.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\packages\System.Runtime.4.3.0\lib\net462\System.Runtime.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Algorithms, Version=4.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\packages\System.Security.Cryptography.Algorithms.4.3.0\lib\net463\System.Security.Cryptography.Algorithms.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Encoding, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\packages\System.Security.Cryptography.Encoding.4.3.0\lib\net46\System.Security.Cryptography.Encoding.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Primitives, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\packages\System.Security.Cryptography.Primitives.4.3.0\lib\net46\System.Security.Cryptography.Primitives.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.X509Certificates, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\packages\System.Security.Cryptography.X509Certificates.4.3.0\lib\net461\System.Security.Cryptography.X509Certificates.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.ValueTuple">
+      <HintPath>..\packages\System.ValueTuple.4.4.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="AssemblyInfo.fs" />
+    <Compile Include="Implementations.fs" />
+    <Compile Include="Program.fs" />
+    <Compile Include="Selling.fs" />
+    <Content Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Consensus\Consensus.fsproj">
+      <Project>{5ec4457b-615a-4bbd-b3d5-d0e311b9d5e9}</Project>
+      <Name>Consensus</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Messaging\Messaging.fsproj">
+      <Project>{44277422-32e3-4f1b-bd6d-153b7a621444}</Project>
+      <Name>Messaging</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(FSharpTargetsPath)" Condition="Exists('$(FSharpTargetsPath)')" />
+</Project>

--- a/src/Swaps/packages.config
+++ b/src/Swaps/packages.config
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="FSharp.Compiler.Tools" version="10.0.1" targetFramework="net45" />
+  <package id="FSharp.Core" version="4.3.4" targetFramework="net45" />
+  <package id="NBitcoin" version="4.1.1.1" targetFramework="net471" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net471" />
+  <package id="QBitNinja.Client" version="1.0.3.47" targetFramework="net471" />
+  <package id="System.IO" version="4.3.0" targetFramework="net471" />
+  <package id="System.Net.Http" version="4.3.2" targetFramework="net471" />
+  <package id="System.Net.Requests" version="4.3.0" targetFramework="net471" />
+  <package id="System.Runtime" version="4.3.0" targetFramework="net471" />
+  <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="net471" />
+  <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net471" />
+  <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net471" />
+  <package id="System.Security.Cryptography.X509Certificates" version="4.3.0" targetFramework="net471" />
+  <package id="System.ValueTuple" version="4.4.0" targetFramework="net45" />
+</packages>

--- a/src/zenprotocol.sln
+++ b/src/zenprotocol.sln
@@ -85,6 +85,8 @@ Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "AddressDB.Tests", "AddressD
 EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "SerializationBenchmark", "SerializationBenchmark\SerializationBenchmark.fsproj", "{CBF2B4FB-5E3F-41AE-BAFF-AA7DCCB55051}"
 EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Swaps", "Swaps\Swaps.fsproj", "{56976F07-D182-4388-88F3-6FEB8C85C755}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -179,6 +181,10 @@ Global
 		{CBF2B4FB-5E3F-41AE-BAFF-AA7DCCB55051}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CBF2B4FB-5E3F-41AE-BAFF-AA7DCCB55051}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CBF2B4FB-5E3F-41AE-BAFF-AA7DCCB55051}.Release|Any CPU.Build.0 = Release|Any CPU
+		{56976F07-D182-4388-88F3-6FEB8C85C755}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{56976F07-D182-4388-88F3-6FEB8C85C755}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{56976F07-D182-4388-88F3-6FEB8C85C755}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{56976F07-D182-4388-88F3-6FEB8C85C755}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This pull request focuses on the selling flow (the person selling Zens) for BTC-ZP atomic swaps.

`Swaps.Selling` describes the state machine and transitions between states.
`Swaps.Imp` implements the various functions used by the state transitions.

this includes:
* starting a new order
* verifying submitted bitcoin transaction sent by the buyer
* creating and activating new contract
* verifying confirmed bitcoin payment on successful sale
* allowing swap to fail on timeout (no bitcoin payment confirmed until swap expiry)

**TODO**:
* entire buyer flow
* minimal btc wallet for buyer
* add functionality to restore ZP funds from expired contract
* tests for selling flow (normally I write tests first... but while learning F#, starting with types seemed easier)
* currently uses placeholder for contract code (currently in a [separate repo](https://github.com/its-ah-me/swap-contract/blob/master/BitcoinSwap.fst)) - can use native templates?
* F# executable to tie both flows together, and expose API
* small JS wrapper for said API